### PR TITLE
python-gnupg 0.5.3 - fix version number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "python-gnupg" %}
-{% set version = "0.5.0" %}
+{% set version = "0.5.3" %}
 {% set skip_test_invalid_outputs = "" %}
 {% set skip_test_invalid_outputs = skip_test_invalid_outputs + "-k 'not test_invalid_outputs'" %} # [linux]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 70758e387fc0e0c4badbcb394f61acbe68b34970a8fed7e0f7c89469fe17912a
+  sha256: 290d8ddb9cd63df96cfe9284b9b265f19fd6e145e5582dc58fd7271f026d0a47
 
 build:
   # gnupg isn't available on windows nor s390x


### PR DESCRIPTION
python-gnupg :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-6521](https://anaconda.atlassian.net/browse/PKG-6521)

### Explanation of changes:

- Fix package version


[PKG-6521]: https://anaconda.atlassian.net/browse/PKG-6521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ